### PR TITLE
Fix typo in Lapack section

### DIFF
--- a/docs/user_guide/decompositions_and_lapack.mdx
+++ b/docs/user_guide/decompositions_and_lapack.mdx
@@ -327,11 +327,11 @@ your `Cargo.toml` file by enabling the related feature for your
 * [Accelerate](https://developer.apple.com/reference/accelerate) enabled by the
   `accelerate` feature on Mac OS only.
 
-The `openblas` feature is enabled by default. The following examples shows how
+The `netlib` feature is enabled by default. The following examples shows how
 to enable `Accelerate` instead:
 
 ```yaml
-[dependencies.nalgebra_lapack]
+[dependencies.nalgebra-lapack]
 version = "*" # Replace the * by the latest version number.
 default-features = false
 features = [ "Accelerate" ]


### PR DESCRIPTION
Hi! I noticed that there is a typo in the `Cargo.toml` snippet on the ["Setting up
nalgebra-lapack"](https://nalgebra.org/docs/user_guide/decompositions_and_lapack#setting-up-nalgebra-lapack) page.

Also, the docs say that `openblas` is the default Lapack implementation, but it looks like `nalgebra-lapack` actually defaults to `netlib`, so I changed that as well.