### PR TITLE
Fix broken links due to trailing `/`

### DIFF
--- a/docs/user_guide/cg_recipes.mdx
+++ b/docs/user_guide/cg_recipes.mdx
@@ -11,14 +11,14 @@ import TabItem from '@theme/TabItem';
 This section describes how to perform some operations common for Computer
 Graphics (CG). Note that while the 3D Computer Graphics community is used to
 work almost exclusively with 4×4 matrices, **nalgebra** defines a wider number
-of [transformation types](points_and_transformations/#transformations) that
+of [transformation types](./points_and_transformations.mdx#transformations) that
 the user is strongly encouraged to use instead.
 
 :::info
 You are encouraged to look at the [**nalgebra-glm**](https://crates.io/crates/nalgebra-glm) crate as well. This provides
 a simpler interface for manipulating vectors and matrices using homogeneous
 coordinates. It is inspired from the popular C++ [GLM](https://glm.g-truc.net/) library. You will find
-more details on a [dedicated page](nalgebra_glm.mdx) of this user guide.
+more details on a [dedicated page](./nalgebra_glm.mdx) of this user guide.
 :::
 
 ## Transformations using Matrix4
@@ -30,7 +30,7 @@ so-called *homogeneous coordinates*, they do not have provide strong guarantees
 regarding their properties. For example, a method that takes a `Matrix4` in
 argument cannot have the guarantee that it is a pure rotation, an
 isometry, or even an arbitrary but invertible transformation! That's why all
-the [transformation types](points_and_transformations/#transformations) are
+the [transformation types](./points_and_transformations.mdx#transformations) are
 recommended instead of raw matrices.
 
 However, it is sometimes convenient to work directly with 4x4 matrices.
@@ -51,8 +51,8 @@ Method                     | Description
 `::new_rotation_wrt_point(axang, pt)` | A composition of rotation and translation such that the point `pt` is left invariant. The rotational part is specified as a rotation axis multiplied by the rotation angle. |
 `::from_scaled_axis(axang)`   | A pure rotation matrix specified by a rotation axis multiplied by the rotation angle. |
 `::from_euler_angle(r, p, y)` | A pure rotation matrix from Euler angles applied in order: roll - pitch - yaw. |
-`::new_orthographic(...)`     | An [orthographic](projections/#orthographic-projection) projection matrix.  |
-`::new_perspective(...)`      | A [perspective](projections/#perspective-projection) projection matrix.     |
+`::new_orthographic(...)`     | An [orthographic](./projections.mdx#orthographic-projection) projection matrix.  |
+`::new_perspective(...)`      | A [perspective](./projections.mdx#perspective-projection) projection matrix.     |
 `::new_observer_frame(eye, target, up)` | A composition of rotation and translation corresponding to the local frame of a viewer standing at the point `eye` and looking toward `target`. The `up` direction is the vertical direction. |
 `::look_at_rh(...)`           | A right-handed look-at view matrix. |
 `::look_at_lh(...)`           | A left-handed look-at view matrix.  |
@@ -163,7 +163,7 @@ of three transformations:
    different for every camera.
 3. The <u>projection</u> that translates and stretches the displayable part of
    the scene so that it fits into the double unit cube (aka. Normalized Device
-   Coordinates). We already discussed it [there](projections). There is
+   Coordinates). We already discussed it [there](./projections.mdx). There is
    usually only one projection per display.
 
 Note that it is also common to construct only a View-Projection matrix and let
@@ -174,7 +174,7 @@ completeness, our example will deal with the model transformation as well.
 The model and view transformations are direct isometries. Thus, we can simply
 use the dedicated `Isometry3` type. The projection is not an isometry and
 requires the use of a raw `Matrix4` or a dedicated
-[projection](projections) type like `Perspective3`.
+[projection](./projections.mdx) type like `Perspective3`.
 
 ```rust
 // Our object is translated along the x axis.
@@ -213,7 +213,7 @@ let model_view_projection = projection.unwrap() * (view * model).to_homogeneous(
 
 ## Screen-space to view-space
 It is the projection matrix task to stretch and translate the displayable 3D
-objects into the [double unit cube](projections), i.e., it transforms points
+objects into the [double unit cube](./projections.mdx), i.e., it transforms points
 from view-coordinates (the camera local coordinate system) to Normalized Device
 Coordinates (aka. clip-space).  Then, the screen itself will contain everything
 that can be seen from the cube's face located on the plane $z = -1$.
@@ -278,7 +278,7 @@ specific way in-memory. Using the `.as_slice()` method of raw matrices and
 vectors, one can retrieve a reference to a contiguous array containing all
 components in column-major order. Note that this method will not exist for
 matrices that do not own their data, e.g. [matrix
-slices](vectors_and_matrices/#matrix-slicing).
+slices](./vectors_and_matrices.mdx#matrix-slicing).
 
 ```rust
 let v = Vector3::new(1.0f32, 0.0, 1.0);
@@ -303,7 +303,7 @@ be converted into arrays directly so you will have to convert them to raw
 matrices first. The underlying 3×3 or 4×4 matrix of `RotationMatrix3` and
 `RotationMatrix2` can be directly retrieved by the `.matrix()` method. All the
 other transformations must first be converted into their [homogeneous
-coordinates](points_and_transformations/#homogeneous-coordinates) representation
+coordinates](./points_and_transformations.mdx#homogeneous-coordinates) representation
 using the method `.to_homogeneous()`. This will return a `Matrix2` or a
 `Matrix3` that may then be reinterpreted as arrays.
 

--- a/docs/user_guide/decompositions_and_lapack.mdx
+++ b/docs/user_guide/decompositions_and_lapack.mdx
@@ -9,12 +9,12 @@ import TabItem from '@theme/TabItem';
 
 Matrix decomposition is a family of methods that aim to represent a matrix as
 the product of several matrices. Those factors can either allow more efficient
-operations like inversion or [linear system resolution](#linear-system-resolution), and might provide some
+operations like inversion or [linear system resolution](./decompositions_and_lapack.mdx#linear-system-resolution), and might provide some
 insight regarding intrinsic properties of some data to be analysed (e.g. by
 observing singular values, eigenvectors, etc.) Some decompositions are
 implemented in pure Rust or available as bindings to a Fortran Lapack
 implementation (refer to the section on
-[nalgebra-lapack](#lapack-integration)). In this section, we present
+[nalgebra-lapack](./decompositions_and_lapack.mdx#lapack-integration)). In this section, we present
 decompositions implemented in pure Rust for **real or complex** matrices:
 
 Decomposition            | Factors                   | Rust methods

--- a/docs/user_guide/nalgebra_glm.mdx
+++ b/docs/user_guide/nalgebra_glm.mdx
@@ -53,7 +53,7 @@ Here are a few rules chosen arbitrarily for **nalgebra-glm**:
 * Functions operating on vector will often end with the `_vec` suffix, possibly followed by the dimension of vector, e.g., `glm::rotate_vec2`.
   Similar functions operating on scalar numbers only often end with the `_scalar` suffix.
 * Every function related to quaternions start with the `quat_` prefix, e.g., `glm::quat_dot(q1, q2)`.
-* All the conversion functions have unique names as described [below](#conversions).
+* All the conversion functions have unique names as described [below](./nalgebra_glm.mdx#conversions).
 
 ### Should I use nalgebra or nalgebra-glm?
 That depends on your tastes and your background. **nalgebra** is more powerful overall since it allows stronger typing,
@@ -72,7 +72,7 @@ Keep in mind that **nalgebra-glm** is just a different API for **nalgebra**! You
 and benefit from both their advantages: use **nalgebra-glm** when type-level restrictions are not important,
 and **nalgebra** itself when you need more expressive types, and more powerful linear algebra operations like
 matrix factorizations and slicing. Remember that all the **nalgebra-glm** types are just aliases to **nalgebra** types,
-and keep in mind it is possible to convert, e.g., an `Isometry3` to a `Mat4` and vice-versa (see the [conversions section](#conversions)).
+and keep in mind it is possible to convert, e.g., an `Isometry3` to a `Mat4` and vice-versa (see the [conversions section](nalgebra_glm.mdx#conversions)).
 :::
 
 # Features overview
@@ -81,7 +81,7 @@ on the rustdoc-generated [documentation](https://docs.rs/nalgebra-glm). Mathemat
 speaking, **nalgebra-glm** supports all the common transformations like rotations, translations, scaling, shearing,
 and projections but operating in homogeneous coordinates. This means all the 2D transformations are
 expressed as 3x3 matrices, and all the 3D transformations as 4x4 matrices. This is less computationally-efficient
-and memory-efficient than nalgebra's [transformation types](https://www.nalgebra.org/points_and_transformations/#transformations),
+and memory-efficient than nalgebra's [transformation types](./points_and_transformations/#transformations),
 but this has the benefit of being simpler to use.
 
 ### Vector and matrix construction

--- a/docs/user_guide/points_and_transformations.mdx
+++ b/docs/user_guide/points_and_transformations.mdx
@@ -47,10 +47,10 @@ point. In particular:
 * For convenience, you may compute the center of two points using the
   free function `na::center(a, b)`.
 * The [homogeneous
-  coordinates](#homogeneous-coordinates) of a point
+  coordinates](./points_and_transformations.mdx#homogeneous-coordinates) of a point
   usually end with a `1` while those of a vector always ends with a `0`.
 * Points are affected by the translational component of
-  [transformations](#transformations) while vectors are only rotated and
+  [transformations](./points_and_transformations.mdx#transformations) while vectors are only rotated and
   scaled:
 
 ```rust
@@ -73,7 +73,7 @@ Constructor                 | Effect
 ----------------------------|-----------
 `::origin()`                | Builds the point with all its coordinates set to zero.
 `::from_coordinates(v)`     | Builds the point with coordinates vector equal to `v`.
-`::from_homogeneous(v)`     | Builds a point with the given [homogeneous coordinates](#homogeneous-coordinates), i.e., with all its components divided by the last one (which is then removed).
+`::from_homogeneous(v)`     | Builds a point with the given [homogeneous coordinates](./points_and_transformations.mdx#homogeneous-coordinates), i.e., with all its components divided by the last one (which is then removed).
 `::new(x, y, ...)`          | Builds the point with the given coordinates. Works only for points with a dimension known at compile-time and smaller than 6. |
 `Bounded::max_value()`      | Builds the point with all its coordinates set to the maximal value of the underlying scalar type.
 `Bounded::min_value()`      | Builds the point with all its coordinates set to the minimal value of the underlying scalar type.
@@ -124,7 +124,7 @@ aliases for the parametrized type `TransformBase<..., Category>` where its last
 type parameter `Category` specifies which of the three variants is represented.
 Note that raw matrices can also be interpreted as general transformations that
 are not necessarily invertible. This may be useful in a [generic
-context](generic_programming/#transformation-genericity).
+context](./generic_programming.mdx#transformation-genericity).
 
 Transformations can be composed (by multiplication) even if they do not have
 the same type. The type of the composition result is the most general
@@ -325,7 +325,7 @@ computing a point's homogeneous coordinates will append a `1`:
 
 </div>
 
-This subtle difference reflects the fact emphasized at the [beginning](#points)
+This subtle difference reflects the fact emphasized at the [beginning](./points_and_transformations.mdx#points)
 of this chapter: transformations do not have the same effect on points as on
 vectors. The `0` appended to vectors will cancel the translational component of
 any transformation; the `1` appended to points will let it be translated

--- a/docs/user_guide/projections.mdx
+++ b/docs/user_guide/projections.mdx
@@ -29,8 +29,8 @@ e.g., OpenGL, because the coordinate system of the screen is left-handed.
 
 
 Currently, **nalgebra** defines only the 3D [orthographic
-projection](#orthographic-projection) and the 3D [perspective
-projection](#perspective-projection), aka., `Orthographic3` and `Perspective3`.
+projection](./projections.mdx#orthographic-projection) and the 3D [perspective
+projection](./projections.mdx#perspective-projection), aka., `Orthographic3` and `Perspective3`.
 They both store a 4x4 homogeneous transformation matrix internally which can be
 retrieved by-value using the `.unwrap()` or `.to_homogeneous()` methods. A
 reference can be obtained with `.as_matrix()`. The projection matrix inverse
@@ -41,11 +41,11 @@ much more efficient than calling the inverse method on the raw homogeneous
 Projection types can transform points and vectors using the
 `.project_point(...)` and `.project_vector(...)` methods. The latter ignores
 the translational part of the projection because the input is a vector
-(remember the [semantic difference](points_and_transformations/#points)
+(remember the [semantic difference](./points_and_transformations.mdx#points)
 between points and vectors). Because projections following our convention are
 invertible, it is possible to apply the inverse projection to points using
 `.unproject_point(...)`. This is typically used for screen-space coordinates to
-view-space coordinates [conversion](cg_recipes/#screen-space-to-view-space).
+view-space coordinates [conversion](./cg_recipes.mdx#screen-space-to-view-space).
 
 ## Orthographic projection
 An orthographic projection `Orthographic3` maps a rectangular axis-aligned
@@ -110,7 +110,7 @@ to the viewer.
 The viewer of the perspective projection is always assumed to be located at the
 origin and to look toward the $-z$ axis. Changing the viewer position and
 orientation requires an additional isometry (in a separate data structure) to
-form a [view-projection](cg_recipes/#build-a-mvp-matrix) transformation. A
+form a [view-projection](./cg_recipes.mdx#build-a-mvp-matrix) transformation. A
 perspective projection is characterized by:
 
 Property | Meaning

--- a/docs/user_guide/quick_reference.mdx.old
+++ b/docs/user_guide/quick_reference.mdx.old
@@ -9,18 +9,18 @@ import TabItem from '@theme/TabItem';
 
 Free functions are noted with a leading `::` while methods start with a dot.
 Most types are type aliases. Refer to the [API
-documentation](../rustdoc_nalgebra) for details about the functions arguments
+documentation](../rustdoc_nalgebra.mdx) for details about the functions arguments
 and type parameters.
 
-* [Matrices and vectors](#matrices-and-vectors)
-    * [Construction](#construction), [Common methods](#common-methods), [Slicing](#slicing), [Resizing](#resizing)
-    * [Blas operations](#blas-operations)
-    * [Decompositions](#decompositions)
-    * [Computer graphics](#computer-graphics)
-* [Geometry](#geometry)
-    * [Points and transformations](#geometry)
-    * [Projections](#projections)
-* [Data storages and allocators](#data-storage-and-allocators)
+* [Matrices and vectors](./quick_reference.mdx#matrices-and-vectors)
+    * [Construction](./quick_reference.mdx#construction), [Common methods](./quick_reference.mdx#common-methods), [Slicing](./quick_reference.mdx#slicing), [Resizing](./quick_reference.mdx#resizing)
+    * [Blas operations](./quick_reference.mdx#blas-operations)
+    * [Decompositions](./quick_reference.mdx#decompositions)
+    * [Computer graphics](./quick_reference.mdx#computer-graphics)
+* [Geometry](./quick_reference.mdx#geometry)
+    * [Points and transformations](./quick_reference.mdx#geometry)
+    * [Projections](./quick_reference.mdx#projections)
+* [Data storages and allocators](./quick_reference.mdx#data-storage-and-allocators)
 
 Serialization with [serde](https://serde.rs) can be enabled by enabling the
 **serde-serialize** feature.
@@ -316,7 +316,7 @@ Other operations that work like blas operations (i.e., in-place and real coeffic
 
 ### Decompositions
 All matrix decompositions are implemented in Rust and operate on Real matrices
-only. Refer to [Lapack integration](#nalgebra-lapack) for lapack-based decompositions.
+only. Refer to [Lapack integration](./quick_reference.mdx#nalgebra-lapack) for lapack-based decompositions.
 
 `.bidiagonalize()`            <span style={{float:'right'}}>Bidiagonalization of a general matrix.</span><br />
 `.symmetric_tridiagonalize()` <span style={{float:'right'}}>Tridiagonalization of a general matrix.</span><br />
@@ -342,7 +342,7 @@ iteration (set to infinite by default):
 ### Lapack integration
 Lapack-based decompositions are available using the **nalgebra-lapack** crate.
 Refer the the [dedicated
-section](decompositions_and_lapack/#lapack-integration) for details regarding
+section](./decompositions_and_lapack.mdx#lapack-integration) for details regarding
 its use and the choice of backend (OpenBLAS, netlib, or Accelerate) The
 following factorization are implemented:
 

--- a/docs/user_guide/vectors_and_matrices.mdx
+++ b/docs/user_guide/vectors_and_matrices.mdx
@@ -216,7 +216,7 @@ assert_eq!(Vector6::c(), Vector6::new(0.0, 0.0, 0.0, 0.0, 0.0, 1.0));
 
 Adding a `_axis` suffix to those constructors, e.g., `::y_axis()`, will create
 a unit vector wrapped into the `Unit`
-[structure](performance_tricks/#the-unit-wrapper). For example,
+[structure](./performance_tricks.mdx#the-unit-wrapper). For example,
 `Vector2::y_axis()` will create a `Unit<Vector2<T>>` with its the second
 component of the underlying vector set to `1`.
 
@@ -370,7 +370,7 @@ type, it can usually be used just like a plain, non-view matrix besides three ex
 
 1. Methods that require a `&mut self` cannot be called on non-mutable views.
 2. Matrix views cannot be created out of thin air using the methods shown in
-   the [Matrix construction](#matrix_construction) section. One must already
+   the [Matrix construction](./vectors_and_matrices.mdx#matrix_construction) section. One must already
    have an instance of a matrix or another view and use one of the dedicated
    methods shown thereafter.
 3. Assignment operators do not work on any kind of view, i.e., one cannot
@@ -451,7 +451,7 @@ a dynamically-sized matrix.
 
 ## Matrix resizing
 The number of rows or columns of a matrix can be modified by adding or removing
-some of them. Similarly to [views](#matrix-views), two variants exist:
+some of them. Similarly to [views](./vectors_and_matrices.mdx#matrix-views), two variants exist:
 
 
 * **"Fixed resizing"** where the number of rows or columns to be removed or

--- a/docs/user_guide/wasm_and_embedded_targets.mdx
+++ b/docs/user_guide/wasm_and_embedded_targets.mdx
@@ -11,9 +11,9 @@ Linear algebra can of course be dramatically useful for browser applications
 or embedded applications. For example, vector, matrix, and geometric operations
 are must-haves for any game running on the browser. Also, you may need matrix decompositions
 to perform machine-learning related data analysis on an embedded program. Luckily **nalgebra**
-supports both [compiling for wasm](#for-browser-applications) and deactivating its
+supports both [compiling for wasm](./wasm_and_embedded_targets.mdx#for-browser-applications) and deactivating its
 link to the Rust standard library so that it becomes
-[compilable for targets without libstd](#for-embedded-development).
+[compilable for targets without libstd](./wasm_and_embedded_targets.mdx#for-embedded-development).
 
 ## For browser applications
 All features of the **nalgebra** crate, including pure-rust implementations of matrix


### PR DESCRIPTION
- Fix https://github.com/dimforge/nalgebra.rs/issues/76

Solution: Use file path rather than url paths.

Prompted by https://github.com/facebook/docusaurus/issues/8693#issuecomment-1441547554

More info https://docusaurus.io/docs/markdown-features/links.

- Similar fix as https://github.com/dimforge/rapier.rs/pull/122